### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [Glider,GliderSwiftLog,GliderELK,GliderNetWatcher,GliderSentry]
+    - documentation_targets: [Glider]


### PR DESCRIPTION
Documentation building and hosting on SPI is failing because the config file references non-existing targets:

```
Build complete! (0.12s)
error: no target named 'GliderSwiftLog'

compatible targets: 'Glider'"
```