### PR TITLE
Fixed minimum transport accept level not accepting the minimum value

### DIFF
--- a/Glider/Sources/Log/Additional Structures/Level.swift
+++ b/Glider/Sources/Log/Additional Structures/Level.swift
@@ -112,7 +112,7 @@ extension Level {
             return true
         }
 
-        return self.rawValue < minLevel.rawValue
+        return self.rawValue <= minLevel.rawValue
     }
     
     #if os(iOS) || os(tvOS) || os(macOS)

--- a/Tests/GliderTests/Core+Tests.swift
+++ b/Tests/GliderTests/Core+Tests.swift
@@ -57,6 +57,7 @@ final class CoreTests: XCTestCase {
     /// so you can avoid to write all the messages on it even if logger accepts them.
     func test_minimumTransportAcceptLevel() throws {
         var minAcceptedLevel: Glider.Level? = .error
+        var passedCountWhenSet = 0
         var passedCountWhenNil = 0
         
         let transport = TestTransport { event, _ in
@@ -64,6 +65,7 @@ final class CoreTests: XCTestCase {
             
             if let minAcceptedLevel = minAcceptedLevel {
                 XCTAssertTrue(event.level <= minAcceptedLevel)
+                passedCountWhenSet += 1
             } else {
                 passedCountWhenNil += 1
             }
@@ -84,6 +86,8 @@ final class CoreTests: XCTestCase {
         log.info?.write(msg: "[SET] Should pass the log service but not the minimum accepted level for transport")
         log.error?.write(msg: "[SET] Should pass both")
         log.critical?.write(msg: "[SET] Should pass both")
+        
+        XCTAssertEqual(passedCountWhenSet, 2)
         
         // ignore
         transport.minimumAcceptedLevel = nil


### PR DESCRIPTION
## DISCUSSION

This implementation fixes a bug that would not accept writes on transports with a given level when it's **equal** to the set minimum level.

This also updates the corresponding unit test.